### PR TITLE
Fixed error message for invalid format option

### DIFF
--- a/index.js
+++ b/index.js
@@ -56,7 +56,7 @@ if (isNaN(amount) || amount < 1) {
 }
 
 if (format !== "html" && format !== "txt") {
-	throw new Error("--format must be “html” or “txt” (default: html)");
+	throw new Error("--format must be “html” or “txt” (default: txt)");
 }
 
 if (type !== "li" && type !== "p") {


### PR DESCRIPTION
It seems the default value for `--format` is `txt`
Ref: https://github.com/hail2u/hail2u-ipsum/blob/main/index.js#L19